### PR TITLE
Add JRDB conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # codex-jrdbml
+
+Utilities for working with JRDB data.
+
+## Scripts
+
+- `scripts/jrdb_convert.py` – Convert fixed-width JRDB text files found in
+  `~/jrdb_input` into UTF-8 CSVs written to `~/jrdb_csv`.

--- a/scripts/jrdb_convert.py
+++ b/scripts/jrdb_convert.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Convert JRDB fixed-width text files to CSV.
+
+This script reads all files under ``~/jrdb_input`` assumed to be
+SHIFT_JIS encoded fixed-width text files and outputs CSV versions
+under ``~/jrdb_csv`` encoded in UTF-8.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import pandas as pd
+
+
+def convert_file(path: Path, out_dir: Path) -> None:
+    """Convert a single fixed-width file to CSV."""
+    df = pd.read_fwf(path, encoding="cp932", dtype=str, header=None)
+    out_path = out_dir / (path.stem + ".csv")
+    df.to_csv(out_path, index=False, encoding="utf-8")
+
+
+def main() -> None:
+    input_dir = Path(os.path.expanduser("~/jrdb_input"))
+    output_dir = Path(os.path.expanduser("~/jrdb_csv"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for f in input_dir.glob("*"):
+        if f.is_file():
+            convert_file(f, output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `jrdb_convert.py` to transform JRDB fixed-width text files into CSV
- document new script in README

## Testing
- `python3 -m py_compile scripts/jrdb_convert.py`
- `python3 scripts/jrdb_convert.py`

------
https://chatgpt.com/codex/tasks/task_e_684d41b418908333af3fc5871a197432